### PR TITLE
program: Use readonly admin

### DIFF
--- a/program/src/accounts/admin.rs
+++ b/program/src/accounts/admin.rs
@@ -9,7 +9,7 @@ pub const ADMIN: [u8; 32] = [
 ];
 
 // Account flags
-pub const NO_DUP_MUT_SIGNER: u32 = 0x01 << 16 | 0x01 << 8 | 0xff; // SIGNER | MUT | NO_DUP
+pub const NO_DUP_SIGNER: u32 = 0x01 << 8 | 0xff; // SIGNER | NO_DUP
 
 pub struct Admin;
 
@@ -17,10 +17,10 @@ impl Admin {
     #[inline(always)]
     /// # Check
     /// Performs the following checks on the Admin account:
-    /// - Checks Admin is a non-duplicate mutable signer (2 CUs)
+    /// - Checks Admin is a non-duplicate signer (2 CUs)
     /// - Checks Admin address matches ADMIN (12 CUs)
     pub unsafe fn check(ptr: *mut u8) {
-        if crate::read::<u32>(ptr, ADMIN_HEADER) != NO_DUP_MUT_SIGNER
+        if crate::read::<u32>(ptr, ADMIN_HEADER) != NO_DUP_SIGNER
             || crate::read::<u64>(ptr, ADMIN_KEY) != *(ADMIN.as_ptr() as *const u64)
             || crate::read::<u64>(ptr, ADMIN_KEY + 0x08) != *(ADMIN.as_ptr().add(8) as *const u64)
             || crate::read::<u64>(ptr, ADMIN_KEY + 0x10) != *(ADMIN.as_ptr().add(16) as *const u64)

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -58,7 +58,7 @@ impl<T: Sized + Copy> From<UpdateInstruction<T>> for Instruction {
         Instruction {
             program_id: ID,
             accounts: vec![
-                AccountMeta::new(update.admin, true),
+                AccountMeta::new_readonly(update.admin, true),
                 AccountMeta::new(update.oracle_pubkey, false),
             ],
             data,


### PR DESCRIPTION
### Problem

Currently the program is expecting the admin account to be mutable, although no update is done on it.

### Solution

Make the admin account readonly.

Note: as it is, the program will fail if the admin account is passed as mutable. It is possible to change the logic and simply ignore the mutable flag.