### PR TITLE
chore: reorder solana deps and actualize readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,17 @@ resolver = "2"
 members = ["example", "program", "sdk"]
 
 [workspace.dependencies]
-serde = { version = "1.0.219" }
-solana-program = { version = "2.3.0" }
-solana-instruction = { version = "2.3.0" }
-solana-compute-budget-interface = { version = "2.2.2" }
-solana-pubkey = { version = "2.3.0" }
-solana-client = { version = "2.2.3" }
-solana-transaction = { version = "2.2.3" }
-solana-keypair = { version = "2.2.3" }
-solana-signer = { version = "2.2.1" }
-solana-account = { version = "2.2.1" }
 mollusk-svm = { version = "0.5.1" }
+serde = { version = "1.0.219" }
+solana-account = { version = "2.2.1" }
+solana-client = { version = "2.2.3" }
+solana-compute-budget-interface = { version = "2.2.2" }
+solana-instruction = { version = "2.3.0" }
+solana-keypair = { version = "2.2.3" }
+solana-program = { version = "2.3.0" }
+solana-pubkey = { version = "2.3.0" }
+solana-signer = { version = "2.2.1" }
+solana-transaction = { version = "2.2.3" }
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Add Doppler SDK and required Solana crates to your `Cargo.toml`:
 doppler-sdk = "0.1.0"
 solana-instruction = "2.3.0"
 solana-pubkey = "2.3.0"
-solana-compute-budget = "2.3.0"
+solana-compute-budget-interface = "2.2.2"
 solana-transaction = "2.3.0"
 solana-keypair = "2.3.0"
+solana-signer = "2.2.1"
 # Add other Solana crates as needed
 ```
 
@@ -55,7 +56,7 @@ pub struct Oracle<T> {
 To achieve the 21 CU performance, configure your transaction with appropriate compute budget:
 
 ```rust
-use solana_compute_budget::ComputeBudgetInstruction;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
 use solana_transaction::Transaction;
 
@@ -128,9 +129,10 @@ instructions.push(update_ix);
 ```rust
 use doppler_sdk::{Oracle, UpdateInstruction};
 use solana_client::rpc_client::RpcClient;
-use solana_compute_budget::ComputeBudgetInstruction;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
-use solana_keypair::{Keypair, Signer};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
 use solana_transaction::Transaction;
 
 async fn update_oracle(
@@ -146,7 +148,7 @@ async fn update_oracle(
         ComputeBudgetInstruction::set_compute_unit_limit(200_000),
         
         // 2. Set priority fee (1000 micro-lamports per CU)
-        ComputeBudgetInstruction::set_compute_unit_price(1000),
+        ComputeBudgetInstruction::set_compute_unit_price(1_000),
         
         // 3. Set loaded accounts data size limit
         ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(32_768),
@@ -203,7 +205,7 @@ for oracle in oracles {
 // DO: Single transaction with multiple updates
 let mut instructions = vec![
     ComputeBudgetInstruction::set_compute_unit_limit(200_000),
-    ComputeBudgetInstruction::set_compute_unit_price(1000),
+    ComputeBudgetInstruction::set_compute_unit_price(1_000),
     ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(65_536),
 ];
 
@@ -306,16 +308,16 @@ let's assume we are going to update a single oracle:
 - Requested compute-budget-limit to 21 (with compute-budget instructions 321 and 471 respectively) CUs
 - Paying priority fee: 1.00 lamports per CU
 
-| Metric                         | Without Instruction          | With 127 byte Limit           |
-| ------------------------------ | ---------------------------- | ----------------------------- |
-| Loaded Account Data Size Limit | 64M                          | 127 bytes                     |
-| Data Size Cost Calculation     | 64M * (4/32K)                | 127 bytes * (4/32K)           |
-| Data Size Cost (CUs)           | 16,000                       | 0.03175                       |
-| Reward to Leader Calculation   | (1 * 5000 + 1 * 321)/2       | (1 * 5000 + 1 * 471)/2        |
-| Reward to Leader (lamports)    | 2,660.5                      | 2,735.5                       |
-| Transaction Cost Formula       | 1*720 + 0*300 + 321 + 16,000 | 1*720 + 0*300 + 471 + 0.03175 |
-| Transaction Cost (CUs)         | 17,041                       | 1,141.03175                   |
-| Priority Score                 | 0.156                        | 2.397                         |
+| Metric                         | Without Instruction              | With 127 byte Limit               |
+| ------------------------------ | -------------------------------- | --------------------------------- |
+| Loaded Account Data Size Limit | 64M                              | 127 bytes                         |
+| Data Size Cost Calculation     | 64M * (4/32K)                    | 127 bytes * (4/32K)               |
+| Data Size Cost (CUs)           | 16,000                           | 0.03175                           |
+| Reward to Leader Calculation   | (1 * 5000 + 1 * 321)/2           | (1 * 5000 + 1 * 471)/2            |
+| Reward to Leader (lamports)    | 2,660.5                          | 2,735.5                           |
+| Transaction Cost Formula       | 1 * 720 + 0 * 300 + 321 + 16,000 | 1 * 720 + 0 * 300 + 471 + 0.03175 |
+| Transaction Cost (CUs)         | 17,041                           | 1,141.03175                       |
+| Priority Score                 | 0.156                            | 2.397                             |
 
 ## Building
 
@@ -397,4 +399,3 @@ For issues, questions, or contributions:
 ## License
 
 MIT License - See LICENSE file for details
-

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,12 +5,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-doppler-sdk = { path = "../sdk" }
 doppler = { path = "../program" }
-solana-instruction = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-transaction = { workspace = true }
-solana-keypair = { workspace = true }
-solana-signer = { workspace = true }
+doppler-sdk = { path = "../sdk" }
 solana-client = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signer = { workspace = true }
+solana-transaction = { workspace = true }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -8,17 +8,15 @@ edition = "2021"
 crate-type = ["lib", "cdylib"]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(target_os, values("solana"))',
-] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("solana"))'] }
 
 [dependencies]
 # lol = "13.37"
 
 [dev-dependencies]
 doppler-sdk = { path = "../sdk" }
-solana-program = { workspace = true }
-solana-instruction = { workspace = true }
-solana-pubkey = { workspace = true }
-solana-account = { workspace = true }
 mollusk-svm = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true }
+solana-program = { workspace = true }
+solana-pubkey = { workspace = true }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 
 [dependencies]
 doppler = { path = "../program" }
+solana-account = { workspace = true }
 solana-instruction = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-account = { workspace = true }


### PR DESCRIPTION
### Problem

all `Cargo` manifests have unordered deps and `README.md` refers to some deprecated imports

### Solution

use alphabetical order for manifests and get rid of deprecation warning in `README.md`