### PR TITLE
Refactor: extract admin pubkey validation into helper function

### DIFF
--- a/doppler/src/admin.rs
+++ b/doppler/src/admin.rs
@@ -25,8 +25,7 @@ impl Admin {
     /// - The memory region must be properly aligned and large enough to hold the
     ///   data being read.
     pub unsafe fn check(ptr: *mut u8) {
-        if crate::read::<u16>(ptr, ADMIN_HEADER) != NO_DUP_SIGNER
-            || !Self::check_admin_pubkey(ptr)
+        if crate::read::<u16>(ptr, ADMIN_HEADER) != NO_DUP_SIGNER || !Self::check_admin_pubkey(ptr)
         {
             #[cfg(target_os = "solana")]
             unsafe {
@@ -38,8 +37,8 @@ impl Admin {
     #[inline(always)]
     unsafe fn check_admin_pubkey(ptr: *const u8) -> bool {
         crate::read::<u64>(ptr, ADMIN_KEY) == *(ADMIN.as_ptr() as *const u64)
-        && crate::read::<u64>(ptr, ADMIN_KEY + 0x08) == *(ADMIN.as_ptr().add(8) as *const u64)
-        && crate::read::<u64>(ptr, ADMIN_KEY + 0x10) == *(ADMIN.as_ptr().add(16) as *const u64)
-        && crate::read::<u64>(ptr, ADMIN_KEY + 0x18) == *(ADMIN.as_ptr().add(24) as *const u64)
-}
+            && crate::read::<u64>(ptr, ADMIN_KEY + 0x08) == *(ADMIN.as_ptr().add(8) as *const u64)
+            && crate::read::<u64>(ptr, ADMIN_KEY + 0x10) == *(ADMIN.as_ptr().add(16) as *const u64)
+            && crate::read::<u64>(ptr, ADMIN_KEY + 0x18) == *(ADMIN.as_ptr().add(24) as *const u64)
+    }
 }

--- a/doppler/src/admin.rs
+++ b/doppler/src/admin.rs
@@ -26,10 +26,7 @@ impl Admin {
     ///   data being read.
     pub unsafe fn check(ptr: *mut u8) {
         if crate::read::<u16>(ptr, ADMIN_HEADER) != NO_DUP_SIGNER
-            || crate::read::<u64>(ptr, ADMIN_KEY) != *ADMIN.as_ptr().cast::<u64>()
-            || crate::read::<u64>(ptr, ADMIN_KEY + 0x08) != *ADMIN.as_ptr().add(8).cast::<u64>()
-            || crate::read::<u64>(ptr, ADMIN_KEY + 0x10) != *ADMIN.as_ptr().add(16).cast::<u64>()
-            || crate::read::<u64>(ptr, ADMIN_KEY + 0x18) != *ADMIN.as_ptr().add(24).cast::<u64>()
+            || !Self::check_admin_pubkey(ptr)
         {
             #[cfg(target_os = "solana")]
             unsafe {
@@ -37,4 +34,12 @@ impl Admin {
             }
         }
     }
+
+    #[inline(always)]
+    unsafe fn check_admin_pubkey(ptr: *const u8) -> bool {
+        crate::read::<u64>(ptr, ADMIN_KEY) == *(ADMIN.as_ptr() as *const u64)
+        && crate::read::<u64>(ptr, ADMIN_KEY + 0x08) == *(ADMIN.as_ptr().add(8) as *const u64)
+        && crate::read::<u64>(ptr, ADMIN_KEY + 0x10) == *(ADMIN.as_ptr().add(16) as *const u64)
+        && crate::read::<u64>(ptr, ADMIN_KEY + 0x18) == *(ADMIN.as_ptr().add(24) as *const u64)
+}
 }

--- a/program/tests/tests.rs
+++ b/program/tests/tests.rs
@@ -8,7 +8,8 @@ use solana_clock::Epoch;
 use solana_instruction::Instruction;
 use solana_pubkey::Pubkey;
 
-#[must_use] pub fn keyed_account_for_admin(key: Pubkey) -> (Pubkey, Account) {
+#[must_use]
+pub fn keyed_account_for_admin(key: Pubkey) -> (Pubkey, Account) {
     (
         key,
         Account::new(10_000_000_000, 0, &solana_sdk_ids::system_program::ID),

--- a/sdk/src/accounts.rs
+++ b/sdk/src/accounts.rs
@@ -48,6 +48,19 @@ pub struct UpdateInstruction<T: Sized + Copy> {
 }
 
 impl<T: Sized + Copy> UpdateInstruction<T> {
+
+    pub fn new(admin: Pubkey, oracle_pubkey: Pubkey, sequence:u64,payload:T) -> Self {
+        Self {
+            admin,
+            oracle_pubkey,
+            oracle:{
+                Oracle {
+                    sequence,
+                    payload
+                }
+            }
+        }
+    }
     pub const fn compute_units(&self) -> u32 {
         SEQUENCE_CHECK_CU
             + ADMIN_VERIFICATION_CU

--- a/sdk/src/accounts.rs
+++ b/sdk/src/accounts.rs
@@ -49,16 +49,11 @@ pub struct UpdateInstruction<T: Sized + Copy> {
 
 impl<T: Sized + Copy> UpdateInstruction<T> {
 
-    pub fn new(admin: Pubkey, oracle_pubkey: Pubkey, sequence:u64,payload:T) -> Self {
+       pub fn new(admin: Pubkey, oracle_pubkey: Pubkey, sequence: u64, payload: T) -> Self {
         Self {
             admin,
             oracle_pubkey,
-            oracle:{
-                Oracle {
-                    sequence,
-                    payload
-                }
-            }
+            oracle: Oracle { sequence, payload },
         }
     }
     pub const fn compute_units(&self) -> u32 {

--- a/sdk/src/accounts.rs
+++ b/sdk/src/accounts.rs
@@ -48,8 +48,7 @@ pub struct UpdateInstruction<T: Sized + Copy> {
 }
 
 impl<T: Sized + Copy> UpdateInstruction<T> {
-
-       pub fn new(admin: Pubkey, oracle_pubkey: Pubkey, sequence: u64, payload: T) -> Self {
+    pub fn new(admin: Pubkey, oracle_pubkey: Pubkey, sequence: u64, payload: T) -> Self {
         Self {
             admin,
             oracle_pubkey,


### PR DESCRIPTION
### **Problem**

The Admin::check function inlined all checks (flags + admin pubkey comparison) inside a single if clause, making the logic harder to read and maintain.

### **Solution**

Refactored the pubkey comparison into a dedicated helper function check_admin_pubkey.
This improves readability by clearly separating account flag validation from pubkey validation, while preserving the same logic and behavior.