### PR TITLE
feat(feeder): off-chain price feeder with pluggable sources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["doppler", "examples", "program", "sdk"]
+members = ["doppler", "examples", "feeder", "program", "sdk"]
 
 [workspace.package]
 repository = "https://github.com/blueshift-gg/doppler"

--- a/feeder/Cargo.toml
+++ b/feeder/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "doppler-feeder"
+description = "Fetch real prices and feed them to a Doppler oracle on an interval."
+repository = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+edition = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+doppler-program = { workspace = true }
+doppler-sdk = { workspace = true }
+solana-client = { workspace = true }
+solana-keypair = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signer = { workspace = true }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+serde_json = "1"
+
+[lib]
+name = "doppler_feeder"
+path = "src/lib.rs"
+
+[[bin]]
+name = "feeder"
+path = "src/main.rs"

--- a/feeder/README.md
+++ b/feeder/README.md
@@ -1,0 +1,82 @@
+# doppler-feeder
+
+The off-chain half of Doppler: fetch real prices and push them to a Doppler oracle
+on an interval. The on-chain program + `doppler-sdk` already make a single update
+~5 lines of code; this crate wraps that in a price **source** + a **run loop** so a
+live feed is one call away.
+
+```rust
+use doppler_feeder::{Coinbase, Feed, Feeder};
+use std::time::Duration;
+
+let feeder = Feeder::new(rpc_url, admin_keypair, Coinbase::usd(), feeds, /*unit_price*/ 1_000);
+feeder.run(Duration::from_secs(60)); // fetch -> push every 60s, forever
+```
+
+## How it works
+
+```
+                 ┌── PriceSource ──┐      ┌──── doppler-sdk ────┐
+ every interval: │ Coinbase.spot() │  ->  │ Builder.add_update  │ -> Solana tx -> oracle account
+                 │ "172.34" -> u64 │      │ seq = push-millis   │
+                 └─────────────────┘      └─────────────────────┘
+```
+
+- **`source.rs`** — `PriceSource` trait + a keyless `Coinbase` USD-spot source.
+  `parse_decimal_to_minor` converts a decimal string to integer minor units
+  (6 decimals) **without floating point**. Swap in Binance / tokens.xyz / a CEX by
+  implementing the trait; nothing else changes.
+- **`lib.rs`** — `Feeder::tick()` pushes one fresh price per `Feed`; a feed that
+  fails (source down, RPC error) is **skipped, never pushed stale**. `Feeder::run()`
+  loops on an interval. The on-chain sequence is push-time millis
+  (`.max(current + 1)`), which is monotonic (the program rejects `new <= current`)
+  and doubles as a freshness stamp.
+
+## Run the POC (local surfpool)
+
+```bash
+# 1. start the local validator with the example oracle accounts loaded
+./surfpool.sh
+
+# 2. feed the example SOL-USDC oracle the live Coinbase SOL price every 60s
+cargo run --bin feeder
+```
+
+Expected output:
+
+```
+doppler feeder: 1 feed(s) every 60s -> http://localhost:8899
+tick @ 1782489...
+  SOL   $172.34       seq=1782489...  3MLXk7YCsq...
+  1/1 feeds updated
+```
+
+Read the oracle account back (or use `examples/single-price-feed`) to confirm the
+sequence advanced and the price matches the live market.
+
+### Config (env vars, no flags yet)
+
+| var | default | meaning |
+|-----|---------|---------|
+| `DOPPLER_RPC` | `http://localhost:8899` | Solana RPC endpoint |
+| `DOPPLER_ADMIN` | `examples/keys/admin-keypair.json` | program admin keypair |
+| `DOPPLER_INTERVAL_SECS` | `60` | push interval |
+
+## What this is / is NOT
+
+This is a **single-source price cache you operate yourself**, not a trustless oracle:
+no quorum, no cross-source validation, no economic security. The price is only as
+good as the source and the operator. Consumers must guard staleness on read.
+
+## Handoff TODO (next slices)
+
+1. **`clap` CLI** — `doppler init` (create the oracle account(s) via
+   `create_account_with_seed`, admin as base) and `doppler run`. This replaces the
+   hardcoded demo config in `main.rs` and unlocks **BTC/ETH/SOL** by creating three
+   accounts instead of reusing the one example SOL account.
+2. **More sources** behind `PriceSource` — Binance, tokens.xyz (needs API key + ToS
+   check on on-chain redistribution).
+3. **Priority fees** — replace the static `unit_price` with a dynamic estimate
+   (`getRecentPrioritizationFees`) for mainnet.
+4. **TS SDK** — mirror `createFeed().run()` for web devs.
+5. **Mainnet** — real admin keypair, user-supplied RPC, low-balance alerting.

--- a/feeder/src/lib.rs
+++ b/feeder/src/lib.rs
@@ -1,0 +1,210 @@
+//! Doppler feeder: fetch real prices and push them to a Doppler oracle on an
+//! interval, using the existing [`doppler_sdk`] transaction builder.
+//!
+//! This is the off-chain half of Doppler: the on-chain program and SDK already
+//! make a single update ~5 lines of code. The feeder wraps that in a price
+//! [`source::PriceSource`] + a [`Feeder::run`] loop so the dumbest dev can keep a
+//! live feed running with one call.
+
+use std::mem::size_of;
+use std::thread::sleep;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use doppler_program::PriceFeed;
+use doppler_sdk::{transaction::Builder, Oracle};
+use solana_client::rpc_client::RpcClient;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+
+pub mod raw;
+pub mod source;
+pub mod tokens;
+pub use raw::RawSource;
+pub use source::{aggregate, scalar_to_minor, Aggregate, Binance, Coinbase, PriceSource};
+pub use tokens::{Assets, FeedType, Quote, Tier, TokensXyz, Variant};
+
+/// Decimals encoded into the on-chain `u64` price (USDC-style, matches the README).
+pub const PRICE_DECIMALS: u32 = 6;
+
+/// A single feed the feeder keeps fresh: a human symbol and the oracle account it writes to.
+pub struct Feed {
+    /// Source symbol, e.g. `"SOL"`.
+    pub symbol: String,
+    /// The on-chain oracle account this symbol's price is written to.
+    pub oracle: Pubkey,
+}
+
+impl Feed {
+    /// Convenience constructor.
+    #[must_use]
+    pub fn new(symbol: impl Into<String>, oracle: Pubkey) -> Self {
+        Self {
+            symbol: symbol.into(),
+            oracle,
+        }
+    }
+}
+
+/// A successful single-feed push.
+pub struct Update {
+    /// Price written, in minor units (scaled by `10^PRICE_DECIMALS`).
+    pub price: u64,
+    /// Monotonic sequence stamped on-chain (push-time millis).
+    pub sequence: u64,
+    /// Confirmed transaction signature.
+    pub signature: String,
+}
+
+/// Drives a set of [`Feed`]s: fetch prices from `source` and push them on-chain
+/// with the hardcoded program admin keypair.
+pub struct Feeder<S: PriceSource> {
+    client: RpcClient,
+    admin: Keypair,
+    source: S,
+    feeds: Vec<Feed>,
+    unit_price: u64,
+}
+
+impl<S: PriceSource> Feeder<S> {
+    /// Build a feeder. `admin` must be the keypair the deployed program expects.
+    /// `unit_price` is the priority fee in micro-lamports per compute unit.
+    #[must_use]
+    pub fn new(rpc_url: &str, admin: Keypair, source: S, feeds: Vec<Feed>, unit_price: u64) -> Self {
+        Self {
+            client: RpcClient::new(rpc_url.to_string()),
+            admin,
+            source,
+            feeds,
+            unit_price,
+        }
+    }
+
+    /// Number of feeds this feeder manages.
+    #[must_use]
+    pub fn feed_count(&self) -> usize {
+        self.feeds.len()
+    }
+
+    /// Push one fresh price for every feed. A feed that fails (source down, RPC
+    /// error) is skipped and logged, never pushed stale. Returns how many feeds
+    /// were successfully updated this tick.
+    pub fn tick(&self) -> usize {
+        let mut updated = 0;
+        for feed in &self.feeds {
+            match self.update_feed(feed) {
+                Ok(u) => {
+                    println!(
+                        "  {:<5} ${:<12} seq={}  {}",
+                        feed.symbol,
+                        format_minor(u.price, PRICE_DECIMALS),
+                        u.sequence,
+                        u.signature
+                    );
+                    updated += 1;
+                }
+                Err(e) => eprintln!("  {:<5} skipped: {e}", feed.symbol),
+            }
+        }
+        updated
+    }
+
+    /// Fetch + push a single feed. Returns the [`Update`] on success.
+    fn update_feed(&self, feed: &Feed) -> Result<Update, String> {
+        // 1. Fetch the live price. On failure, propagate so the feed is skipped.
+        let price = self.source.price_minor(&feed.symbol, PRICE_DECIMALS)?;
+
+        // 2. Read the current sequence so the new one is strictly greater. The
+        //    program rejects `new <= current`. Push-time millis is monotonic and
+        //    doubles as a freshness stamp; `.max(current + 1)` guards against a
+        //    clock skew or a pre-seeded account sequence.
+        let expected = size_of::<Oracle<PriceFeed>>();
+        let current = self
+            .client
+            .get_account_data(&feed.oracle)
+            .ok()
+            .filter(|data| data.len() == expected)
+            .map(|data| Oracle::<PriceFeed>::from_bytes(data.as_slice()).sequence)
+            .unwrap_or(0);
+        let sequence = now_millis().max(current + 1);
+
+        // 3. Build + send with the existing SDK builder.
+        let blockhash = self
+            .client
+            .get_latest_blockhash()
+            .map_err(|e| format!("blockhash: {e}"))?;
+        let tx = Builder::new(&self.admin)
+            .add_oracle_update(
+                feed.oracle,
+                Oracle {
+                    sequence,
+                    payload: PriceFeed { price },
+                },
+            )
+            .with_unit_price(self.unit_price)
+            .build(blockhash);
+
+        let signature = self
+            .client
+            .send_and_confirm_transaction(&tx)
+            .map_err(|e| format!("send: {e}"))?
+            .to_string();
+        Ok(Update {
+            price,
+            sequence,
+            signature,
+        })
+    }
+
+    /// Run forever, pushing every `interval`. Blocks the calling thread.
+    pub fn run(&self, interval: Duration) -> ! {
+        loop {
+            println!("tick @ {}", now_millis());
+            let n = self.tick();
+            println!("  {n}/{} feeds updated\n", self.feeds.len());
+            sleep(interval);
+        }
+    }
+}
+
+/// Current unix time in milliseconds, used as the monotonic oracle sequence.
+#[must_use]
+pub fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Format an integer minor-unit price back to a human decimal string for display,
+/// e.g. `format_minor(172_340_000, 6) == "172.34"`. Keeps at least 2 decimals.
+#[must_use]
+pub fn format_minor(value: u64, decimals: u32) -> String {
+    if decimals == 0 {
+        return value.to_string();
+    }
+    let scale = 10u64.pow(decimals);
+    let int = value / scale;
+    let frac = value % scale;
+    let mut frac_str = format!("{frac:0>width$}", width = decimals as usize);
+    while frac_str.len() > 2 && frac_str.ends_with('0') {
+        frac_str.pop();
+    }
+    format!("{int}.{frac_str}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_minor;
+
+    #[test]
+    fn formats_with_trailing_trim() {
+        assert_eq!(format_minor(172_340_000, 6), "172.34");
+        assert_eq!(format_minor(42_000_000_000, 6), "42000.00");
+        assert_eq!(format_minor(100_000, 6), "0.10");
+    }
+
+    #[test]
+    fn zero_decimals_passthrough() {
+        assert_eq!(format_minor(42_000, 0), "42000");
+    }
+}

--- a/feeder/src/main.rs
+++ b/feeder/src/main.rs
@@ -1,0 +1,61 @@
+//! Minimal `doppler feeder` runner.
+//!
+//! For the local surfpool demo this needs no flags: it feeds the example
+//! SOL-USDC oracle with the live Coinbase SOL price every 60s, signing with the
+//! example admin keypair. Override with env vars:
+//!   DOPPLER_RPC=<url>  DOPPLER_ADMIN=<keypair.json>  DOPPLER_INTERVAL_SECS=<n>
+//!
+//! A proper `clap` CLI (`doppler init` / `doppler run`) is the next slice.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use doppler_feeder::{Coinbase, Feed, Feeder};
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::EncodableKey as _;
+
+fn main() {
+    let rpc_url =
+        std::env::var("DOPPLER_RPC").unwrap_or_else(|_| "http://localhost:8899".to_string());
+
+    let interval_secs: u64 = std::env::var("DOPPLER_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(60);
+    let interval = Duration::from_secs(interval_secs);
+
+    let unit_price: u64 = 1_000;
+
+    // Admin keypair the program expects. Defaults to the example key for surfpool.
+    let admin_path: PathBuf = std::env::var("DOPPLER_ADMIN").map_or_else(
+        |_| {
+            [
+                env!("CARGO_MANIFEST_DIR"),
+                "..",
+                "examples",
+                "keys",
+                "admin-keypair.json",
+            ]
+            .iter()
+            .collect()
+        },
+        PathBuf::from,
+    );
+    let admin = Keypair::read_from_file(&admin_path)
+        .unwrap_or_else(|e| panic!("admin keypair not found at {}: {e}", admin_path.display()));
+
+    // symbol -> oracle account. Demo: the example SOL-USDC oracle, fed live SOL-USD.
+    let feeds = vec![Feed::new(
+        "SOL",
+        Pubkey::from_str_const("QUVF91dzXWYvE5FmFEc41JZxRDmNgx8S8P6sNDWYZiW"),
+    )];
+
+    let feeder = Feeder::new(&rpc_url, admin, Coinbase::usd(), feeds, unit_price);
+    println!(
+        "doppler feeder: {} feed(s) every {}s -> {rpc_url}",
+        feeder.feed_count(),
+        interval_secs
+    );
+    feeder.run(interval);
+}

--- a/feeder/src/raw.rs
+++ b/feeder/src/raw.rs
@@ -1,0 +1,162 @@
+//! Generic "raw" JSON HTTP source: teach the feeder a new price API by config,
+//! with no per-API Rust.
+//!
+//! Configure a URL template (`{asset}` / `{symbol}` are substituted), optional
+//! headers / bearer auth, a **JSON Pointer** (RFC 6901, built into `serde_json`) to
+//! the price, and how to aggregate when the pointer lands on an array of numbers.
+//!
+//! ```no_run
+//! use doppler_feeder::{RawSource, Aggregate};
+//! let src = RawSource::get("https://api.coinbase.com/v2/prices/{asset}-USD/spot")
+//!     .select("/data/amount")
+//!     .decimals(6);
+//! let price = src.price("BTC").unwrap();
+//! ```
+//!
+//! JSON Pointer reaches scalars and arrays-of-scalars. For a price buried in an
+//! array of *objects* (e.g. pick the tier1 variants out of tokens.xyz), use the
+//! native [`crate::TokensXyz`], or a JSONPath selector once that's added.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::source::{aggregate, scalar_to_minor, Aggregate, PriceSource};
+
+/// A config-driven JSON HTTP price source.
+pub struct RawSource {
+    client: reqwest::blocking::Client,
+    url: String,
+    headers: Vec<(String, String)>,
+    bearer: Option<String>,
+    pointer: String,
+    aggregate: Aggregate,
+    decimals: u32,
+}
+
+impl RawSource {
+    /// Start a GET source against `url` (a template; `{asset}` is substituted).
+    /// Defaults: no auth, empty pointer (set with `select`), `Aggregate::First`, 6 decimals.
+    #[must_use]
+    pub fn get(url: impl Into<String>) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("doppler-feeder")
+            .build()
+            .expect("failed to build http client");
+        Self {
+            client,
+            url: url.into(),
+            headers: Vec::new(),
+            bearer: None,
+            pointer: String::new(),
+            aggregate: Aggregate::First,
+            decimals: 6,
+        }
+    }
+
+    #[must_use]
+    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((key.into(), value.into()));
+        self
+    }
+
+    #[must_use]
+    pub fn bearer(mut self, token: impl Into<String>) -> Self {
+        self.bearer = Some(token.into());
+        self
+    }
+
+    /// JSON Pointer to the price (a scalar, or an array of scalars to aggregate).
+    #[must_use]
+    pub fn select(mut self, pointer: impl Into<String>) -> Self {
+        self.pointer = pointer.into();
+        self
+    }
+
+    #[must_use]
+    pub fn aggregate(mut self, how: Aggregate) -> Self {
+        self.aggregate = how;
+        self
+    }
+
+    #[must_use]
+    pub fn decimals(mut self, decimals: u32) -> Self {
+        self.decimals = decimals;
+        self
+    }
+
+    /// Fetch and extract the price for `asset` (substituted into the URL template).
+    pub fn price(&self, asset: &str) -> Result<u64, String> {
+        let url = self.url.replace("{asset}", asset).replace("{symbol}", asset);
+        let mut req = self.client.get(&url);
+        for (key, value) in &self.headers {
+            req = req.header(key, value);
+        }
+        if let Some(token) = &self.bearer {
+            req = req.bearer_auth(token);
+        }
+        let body: Value = req
+            .send()
+            .map_err(|e| format!("request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("http error: {e}"))?
+            .json()
+            .map_err(|e| format!("bad json: {e}"))?;
+        pick(&body, &self.pointer, self.decimals, self.aggregate)
+    }
+}
+
+impl PriceSource for RawSource {
+    /// Uses the source's own configured decimals; the trait's `decimals` is ignored.
+    fn price_minor(&self, symbol: &str, _decimals: u32) -> Result<u64, String> {
+        self.price(symbol)
+    }
+}
+
+/// Extract a price from an already-parsed body via JSON Pointer + aggregate.
+/// Split out from the HTTP call so it can be tested without a network.
+pub fn pick(body: &Value, pointer: &str, decimals: u32, how: Aggregate) -> Result<u64, String> {
+    let node = body
+        .pointer(pointer)
+        .ok_or_else(|| format!("pointer {pointer:?} matched nothing"))?;
+    let prices: Vec<u64> = match node {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|x| scalar_to_minor(x, decimals))
+            .collect(),
+        scalar => scalar_to_minor(scalar, decimals).into_iter().collect(),
+    };
+    aggregate(&prices, how).ok_or_else(|| "no parseable price at pointer".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick;
+    use crate::source::Aggregate;
+    use serde_json::json;
+
+    #[test]
+    fn scalar_pointer() {
+        let body = json!({ "data": { "amount": "60333.52" } });
+        assert_eq!(pick(&body, "/data/amount", 6, Aggregate::First), Ok(60_333_520_000));
+    }
+
+    #[test]
+    fn array_of_strings_median() {
+        let body = json!({ "prices": ["1.0", "2.0", "3.0"] });
+        assert_eq!(pick(&body, "/prices", 6, Aggregate::Median), Ok(2_000_000));
+    }
+
+    #[test]
+    fn array_of_numbers_mean() {
+        let body = json!({ "p": [1.0, 2.0, 6.0] });
+        assert_eq!(pick(&body, "/p", 6, Aggregate::Mean), Ok(3_000_000));
+    }
+
+    #[test]
+    fn missing_pointer_errors() {
+        let body = json!({ "data": {} });
+        assert!(pick(&body, "/data/amount", 6, Aggregate::First).is_err());
+    }
+}

--- a/feeder/src/source.rs
+++ b/feeder/src/source.rs
@@ -1,0 +1,293 @@
+//! Price sources for the feeder.
+//!
+//! A [`PriceSource`] turns a human symbol (`"SOL"`) into an integer price scaled
+//! to a fixed number of decimals. Sources never return a stale or guessed value:
+//! on any failure they return `Err` and the feeder skips the tick rather than
+//! pushing bad data on-chain.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// A source of spot prices, keyed by a human symbol such as `"SOL"`.
+pub trait PriceSource {
+    /// Fetch the latest price for `symbol`, returned as an integer scaled by
+    /// `10^decimals` (e.g. `42000.50` at 6 decimals -> `42_000_500_000`).
+    ///
+    /// Returns `Err` on any network, parse, or validation failure so the caller
+    /// can skip the update instead of writing stale/garbage data.
+    fn price_minor(&self, symbol: &str, decimals: u32) -> Result<u64, String>;
+}
+
+/// Coinbase public spot price (`/v2/prices/{BASE}-{QUOTE}/spot`). Keyless and
+/// US-reachable. Maps `"SOL"` -> `SOL-USD`, `"BTC"` -> `BTC-USD`, etc.
+pub struct Coinbase {
+    client: reqwest::blocking::Client,
+    quote: String,
+}
+
+impl Coinbase {
+    /// USD-quoted Coinbase source with a 10s request timeout.
+    #[must_use]
+    pub fn usd() -> Self {
+        Self::new("USD")
+    }
+
+    /// Build a Coinbase source quoted in `quote` (e.g. `"USD"`).
+    #[must_use]
+    pub fn new(quote: &str) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("doppler-feeder")
+            .build()
+            .expect("failed to build http client");
+        Self {
+            client,
+            quote: quote.to_string(),
+        }
+    }
+}
+
+impl PriceSource for Coinbase {
+    fn price_minor(&self, symbol: &str, decimals: u32) -> Result<u64, String> {
+        let url = format!(
+            "https://api.coinbase.com/v2/prices/{symbol}-{}/spot",
+            self.quote
+        );
+        let body: serde_json::Value = self
+            .client
+            .get(&url)
+            .send()
+            .map_err(|e| format!("request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("http error: {e}"))?
+            .json()
+            .map_err(|e| format!("bad json: {e}"))?;
+
+        let amount = body["data"]["amount"]
+            .as_str()
+            .ok_or_else(|| format!("missing data.amount in response: {body}"))?;
+
+        parse_decimal_to_minor(amount, decimals)
+            .ok_or_else(|| format!("unparseable amount {amount:?}"))
+    }
+}
+
+/// Binance public ticker price (`/api/v3/ticker/price?symbol={BASE}{QUOTE}`). Keyless.
+/// Verified shape: `{"symbol":"BTCUSDT","price":"60412.00000000"}`.
+///
+/// `api.binance.com` is geo-restricted in some regions (incl. the US): use
+/// [`Binance::with_base_url`] with `https://data-api.binance.vision` (public market
+/// data) or `https://api.binance.us` if needed. Quote defaults to `USDT` — Binance
+/// has no USD spot pairs.
+pub struct Binance {
+    client: reqwest::blocking::Client,
+    base_url: String,
+    quote: String,
+}
+
+impl Binance {
+    /// USDT-quoted Binance source with a 10s request timeout.
+    #[must_use]
+    pub fn usdt() -> Self {
+        Self::new("USDT")
+    }
+
+    /// Build a Binance source quoted in `quote` (e.g. `"USDT"`, `"USDC"`).
+    #[must_use]
+    pub fn new(quote: &str) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("doppler-feeder")
+            .build()
+            .expect("failed to build http client");
+        Self {
+            client,
+            base_url: "https://api.binance.com".to_string(),
+            quote: quote.to_string(),
+        }
+    }
+
+    /// Override the API base, e.g. `https://data-api.binance.vision` or `https://api.binance.us`.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+impl PriceSource for Binance {
+    fn price_minor(&self, symbol: &str, decimals: u32) -> Result<u64, String> {
+        let pair = format!("{}{}", symbol.to_uppercase(), self.quote);
+        let url = format!("{}/api/v3/ticker/price?symbol={pair}", self.base_url);
+        let body: Value = self
+            .client
+            .get(&url)
+            .send()
+            .map_err(|e| format!("request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("http error: {e}"))?
+            .json()
+            .map_err(|e| format!("bad json: {e}"))?;
+        let price = body["price"]
+            .as_str()
+            .ok_or_else(|| format!("missing price in response: {body}"))?;
+        parse_decimal_to_minor(price, decimals)
+            .ok_or_else(|| format!("unparseable price {price:?}"))
+    }
+}
+
+/// Convert a decimal string like `"42000.57"` into integer minor units scaled by
+/// `10^decimals`, without floating point. Extra fractional precision is truncated
+/// (floored). Returns `None` for anything that is not a plain non-negative decimal.
+#[must_use]
+pub fn parse_decimal_to_minor(s: &str, decimals: u32) -> Option<u64> {
+    let s = s.trim();
+    let (int_part, frac_part) = match s.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (s, ""),
+    };
+    if int_part.is_empty() && frac_part.is_empty() {
+        return None;
+    }
+    if !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if !frac_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+
+    let want = decimals as usize;
+    let mut frac = String::with_capacity(want);
+    for (i, b) in frac_part.bytes().enumerate() {
+        if i == want {
+            break; // truncate extra precision
+        }
+        frac.push(b as char);
+    }
+    while frac.len() < want {
+        frac.push('0'); // pad missing precision
+    }
+
+    let combined = format!("{int_part}{frac}");
+    // Strip leading zeros are fine for u64::from_str; empty int_part means "0".
+    combined.parse::<u64>().ok()
+}
+
+/// Read a JSON scalar (number or decimal string) as integer minor units, scaled by
+/// `10^decimals`. Numbers are formatted to fixed decimals first (no scientific
+/// notation, no float *arithmetic* on the value we keep).
+#[must_use]
+pub fn scalar_to_minor(v: &Value, decimals: u32) -> Option<u64> {
+    match v {
+        Value::String(s) => parse_decimal_to_minor(s, decimals),
+        Value::Number(n) => {
+            let f = n.as_f64()?;
+            if !f.is_finite() || f < 0.0 {
+                return None;
+            }
+            parse_decimal_to_minor(&format!("{f:.prec$}", prec = decimals as usize + 6), decimals)
+        }
+        _ => None,
+    }
+}
+
+/// How to combine multiple prices into one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Aggregate {
+    /// Take the first value as-is.
+    First,
+    /// Median (integer mean of the two middle values when the count is even).
+    Median,
+    /// Arithmetic mean (integer).
+    Mean,
+}
+
+/// Combine prices (minor units) per `how`. `None` if the slice is empty.
+#[must_use]
+pub fn aggregate(prices: &[u64], how: Aggregate) -> Option<u64> {
+    if prices.is_empty() {
+        return None;
+    }
+    Some(match how {
+        Aggregate::First => prices[0],
+        Aggregate::Mean => {
+            let sum: u128 = prices.iter().map(|&p| u128::from(p)).sum();
+            (sum / prices.len() as u128) as u64
+        }
+        Aggregate::Median => {
+            let mut p = prices.to_vec();
+            p.sort_unstable();
+            let mid = p.len() / 2;
+            if p.len() % 2 == 1 {
+                p[mid]
+            } else {
+                ((u128::from(p[mid - 1]) + u128::from(p[mid])) / 2) as u64
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{aggregate, parse_decimal_to_minor, scalar_to_minor, Aggregate};
+    use serde_json::json;
+
+    #[test]
+    fn whole_number() {
+        assert_eq!(parse_decimal_to_minor("42000", 6), Some(42_000_000_000));
+    }
+
+    #[test]
+    fn with_fraction() {
+        assert_eq!(parse_decimal_to_minor("42000.57", 6), Some(42_000_570_000));
+    }
+
+    #[test]
+    fn pads_short_fraction() {
+        assert_eq!(parse_decimal_to_minor("0.1", 6), Some(100_000));
+    }
+
+    #[test]
+    fn truncates_extra_precision() {
+        assert_eq!(parse_decimal_to_minor("0.123456789", 6), Some(123_456));
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        assert_eq!(parse_decimal_to_minor("  12.5  ", 6), Some(12_500_000));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(parse_decimal_to_minor("abc", 6), None);
+        assert_eq!(parse_decimal_to_minor("", 6), None);
+        assert_eq!(parse_decimal_to_minor("1.2.3", 6), None);
+        assert_eq!(parse_decimal_to_minor("-5", 6), None);
+    }
+
+    #[test]
+    fn zero_decimals() {
+        assert_eq!(parse_decimal_to_minor("42000.99", 0), Some(42_000));
+    }
+
+    #[test]
+    fn scalar_handles_numbers_and_strings() {
+        assert_eq!(scalar_to_minor(&json!(60333.52527692134), 6), Some(60_333_525_276));
+        assert_eq!(scalar_to_minor(&json!("172.34"), 6), Some(172_340_000));
+        assert_eq!(scalar_to_minor(&json!(-1.0), 6), None);
+        assert_eq!(scalar_to_minor(&json!(true), 6), None);
+    }
+
+    #[test]
+    fn aggregate_modes() {
+        assert_eq!(
+            aggregate(&[3_000_000, 1_000_000, 2_000_000], Aggregate::Median),
+            Some(2_000_000)
+        );
+        assert_eq!(aggregate(&[1_000_000, 3_000_000], Aggregate::Median), Some(2_000_000));
+        assert_eq!(aggregate(&[1_000_000, 2_000_000, 6_000_000], Aggregate::Mean), Some(3_000_000));
+        assert_eq!(aggregate(&[5, 9], Aggregate::First), Some(5));
+        assert_eq!(aggregate(&[], Aggregate::Median), None);
+    }
+}

--- a/feeder/src/tokens.rs
+++ b/feeder/src/tokens.rs
@@ -1,0 +1,384 @@
+//! Native tokens.xyz "assets API" source.
+//!
+//! tokens.xyz models the world as **asset -> variants -> market metrics**: one
+//! canonical asset (`"bitcoin"`) has many on-chain variants (cbBTC, wBTC, ...),
+//! each a distinct mint with its own market block, tagged with `trustTier` /
+//! `liquidityTier` and an `executionQuality.isEligibleForPrimary` flag.
+//!
+//! Selection has three axes:
+//! - **which assets**  — [`Assets::List`] or [`Assets::All`]
+//! - **which variant** — [`Variant`]: a single variant ([`Variant::Primary`],
+//!   [`Variant::Mint`], [`Variant::All`]) or an aggregate ([`Variant::Median`],
+//!   the median across the trust tiers you allow)
+//! - **which metric**  — [`FeedType::Spot`] today
+//!
+//! ```no_run
+//! use doppler_feeder::{TokensXyz, Assets, Variant, Tier};
+//! let src = TokensXyz::new("API_KEY")
+//!     .assets(Assets::list(["bitcoin", "ethereum", "solana"]))
+//!     .variant(Variant::Median(vec![Tier::Tier1, Tier::Tier2])); // mediated price
+//! let quotes = src.resolve(6).unwrap();
+//! ```
+
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use serde_json::Value;
+
+use crate::source::{aggregate, scalar_to_minor, Aggregate};
+
+/// Endpoint base. Exact host/path + auth still need confirming against the live
+/// assets-api; override with [`TokensXyz::with_base_url`].
+pub const DEFAULT_BASE_URL: &str = "https://api.tokens.xyz";
+
+/// Which assets to feed.
+pub enum Assets {
+    /// Every asset tokens.xyz serves. Requires the list endpoint (see `resolve`).
+    All,
+    /// A specific set of asset ids, e.g. `["bitcoin", "ethereum", "solana"]`.
+    List(Vec<String>),
+}
+
+impl Assets {
+    /// Build [`Assets::List`] from anything string-like.
+    pub fn list<I, S>(ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Assets::List(ids.into_iter().map(Into::into).collect())
+    }
+}
+
+/// tokens.xyz trust/liquidity tier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Tier {
+    Tier1,
+    Tier2,
+    Tier3,
+}
+
+impl Tier {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Tier::Tier1 => "tier1",
+            Tier::Tier2 => "tier2",
+            Tier::Tier3 => "tier3",
+        }
+    }
+}
+
+/// Which variant(s) of an asset to price.
+pub enum Variant {
+    /// The canonical variant: `isEligibleForPrimary`, else tier1 trust+liquidity,
+    /// else the deepest-liquidity variant. One feed per asset.
+    Primary,
+    /// A specific mint address. One feed.
+    Mint(String),
+    /// Every variant — each becomes its own feed.
+    All,
+    /// Median price across variants whose **trust tier** is in the allowed set.
+    /// One mediated feed per asset; more manipulation-resistant than any single
+    /// wrapper. Empty/over-restrictive tier sets yield no quote (skipped).
+    Median(Vec<Tier>),
+}
+
+/// Which market metric goes on-chain.
+pub enum FeedType {
+    /// Spot USD price -> `PriceFeed { price }`.
+    Spot,
+    // Future: MarketData { price, volume, market_cap }, Supply, ...
+}
+
+/// A resolved price quote ready to push to a feed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Quote {
+    /// Canonical asset id, e.g. `"bitcoin"`.
+    pub asset_id: String,
+    /// Human label, e.g. `"cbBTC"` or `"bitcoin median[tier1+tier2]"`.
+    pub label: String,
+    /// Identity used to derive the oracle account: the mint for a single variant,
+    /// or the asset id for an aggregate (median).
+    pub key: String,
+    /// Price in minor units (scaled by `10^decimals`).
+    pub price: u64,
+}
+
+/// Native tokens.xyz source.
+pub struct TokensXyz {
+    client: reqwest::blocking::Client,
+    base_url: String,
+    api_key: String,
+    assets: Assets,
+    variant: Variant,
+    feed: FeedType,
+}
+
+impl TokensXyz {
+    /// New source with the default base URL, an empty asset list, `Variant::Primary`,
+    /// and `FeedType::Spot`.
+    #[must_use]
+    pub fn new(api_key: impl Into<String>) -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent("doppler-feeder")
+            .build()
+            .expect("failed to build http client");
+        Self {
+            client,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            api_key: api_key.into(),
+            assets: Assets::List(Vec::new()),
+            variant: Variant::Primary,
+            feed: FeedType::Spot,
+        }
+    }
+
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    #[must_use]
+    pub fn assets(mut self, assets: Assets) -> Self {
+        self.assets = assets;
+        self
+    }
+
+    #[must_use]
+    pub fn variant(mut self, variant: Variant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    #[must_use]
+    pub fn feed(mut self, feed: FeedType) -> Self {
+        self.feed = feed;
+        self
+    }
+
+    /// Resolve the current selection into concrete [`Quote`]s, scaling prices to
+    /// `decimals`. One request per asset; `Assets::All` first needs the list-assets
+    /// endpoint (not yet wired).
+    pub fn resolve(&self, decimals: u32) -> Result<Vec<Quote>, String> {
+        let FeedType::Spot = &self.feed; // only metric supported today
+        let asset_ids = match &self.assets {
+            Assets::List(ids) => ids.clone(),
+            Assets::All => self.list_all_assets()?,
+        };
+        let mut quotes = Vec::new();
+        for id in &asset_ids {
+            let asset = self.fetch_asset(id)?;
+            quotes.extend(select_quotes(&asset, &self.variant, decimals));
+        }
+        Ok(quotes)
+    }
+
+    /// Fetch one asset's variants document. Path + auth are assumptions to confirm
+    /// against the live API; isolated here so the finisher changes one place.
+    fn fetch_asset(&self, asset_id: &str) -> Result<Value, String> {
+        let url = format!("{}/assets/{asset_id}", self.base_url); // TODO confirm exact path
+        self.client
+            .get(&url)
+            .bearer_auth(&self.api_key) // TODO confirm auth scheme (bearer vs x-api-key)
+            .send()
+            .map_err(|e| format!("request failed: {e}"))?
+            .error_for_status()
+            .map_err(|e| format!("http error: {e}"))?
+            .json()
+            .map_err(|e| format!("bad json: {e}"))
+    }
+
+    /// `Assets::All` needs the list-assets endpoint to enumerate the universe.
+    /// Wire it once the path is known; ship `Assets::List` first.
+    fn list_all_assets(&self) -> Result<Vec<String>, String> {
+        Err("Assets::All not wired yet: need the list-assets endpoint + pagination".to_string())
+    }
+}
+
+/// Select quotes from one asset document per `variant`, scaling price to `decimals`.
+#[must_use]
+pub fn select_quotes(asset: &Value, variant: &Variant, decimals: u32) -> Vec<Quote> {
+    let asset_id = asset["assetId"].as_str().unwrap_or_default();
+    let empty = Vec::new();
+    let variants = asset["variants"].as_array().unwrap_or(&empty);
+
+    match variant {
+        Variant::All => variants
+            .iter()
+            .filter_map(|v| single_quote(asset_id, v, decimals))
+            .collect(),
+        Variant::Mint(m) => variants
+            .iter()
+            .filter(|v| v["mint"].as_str() == Some(m.as_str()))
+            .filter_map(|v| single_quote(asset_id, v, decimals))
+            .collect(),
+        Variant::Primary => pick_primary(variants)
+            .and_then(|v| single_quote(asset_id, v, decimals))
+            .into_iter()
+            .collect(),
+        Variant::Median(tiers) => median_quote(asset_id, variants, tiers, decimals)
+            .into_iter()
+            .collect(),
+    }
+}
+
+/// Pick the canonical variant: `isEligibleForPrimary`, else tier1 trust+liquidity,
+/// else the deepest-liquidity variant.
+#[must_use]
+pub fn pick_primary(variants: &[Value]) -> Option<&Value> {
+    variants
+        .iter()
+        .find(|v| v["executionQuality"]["isEligibleForPrimary"].as_bool() == Some(true))
+        .or_else(|| {
+            variants.iter().find(|v| {
+                v["trustTier"].as_str() == Some("tier1")
+                    && v["liquidityTier"].as_str() == Some("tier1")
+            })
+        })
+        .or_else(|| {
+            variants
+                .iter()
+                .max_by(|a, b| liquidity(a).partial_cmp(&liquidity(b)).unwrap_or(Ordering::Equal))
+        })
+}
+
+/// Median price across variants whose trust tier is allowed. One quote per asset.
+fn median_quote(asset_id: &str, variants: &[Value], tiers: &[Tier], decimals: u32) -> Option<Quote> {
+    let prices: Vec<u64> = variants
+        .iter()
+        .filter(|v| tier_allowed(v, tiers))
+        .filter_map(|v| scalar_to_minor(&v["market"]["price"], decimals))
+        .collect();
+    let price = aggregate(&prices, Aggregate::Median)?;
+    let label_tiers = tiers
+        .iter()
+        .map(|t| t.as_str())
+        .collect::<Vec<_>>()
+        .join("+");
+    Some(Quote {
+        asset_id: asset_id.to_string(),
+        label: format!("{asset_id} median[{label_tiers}]"),
+        key: asset_id.to_string(),
+        price,
+    })
+}
+
+fn tier_allowed(v: &Value, tiers: &[Tier]) -> bool {
+    v["trustTier"]
+        .as_str()
+        .is_some_and(|t| tiers.iter().any(|x| x.as_str() == t))
+}
+
+fn liquidity(v: &Value) -> f64 {
+    v["market"]["liquidity"].as_f64().unwrap_or(0.0)
+}
+
+fn single_quote(asset_id: &str, v: &Value, decimals: u32) -> Option<Quote> {
+    let price = scalar_to_minor(&v["market"]["price"], decimals)?;
+    Some(Quote {
+        asset_id: asset_id.to_string(),
+        label: v["symbol"].as_str().unwrap_or_default().to_string(),
+        key: v["mint"].as_str()?.to_string(),
+        price,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Trimmed real tokens.xyz response for "bitcoin": cbBTC is the primary
+    // (tier1 + isEligibleForPrimary), wBTC is tier2.
+    const BITCOIN: &str = r#"{
+      "assetId": "bitcoin",
+      "variants": [
+        {
+          "variantId": "bitcoin:cbBTC",
+          "mint": "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij",
+          "symbol": "cbBTC",
+          "market": { "price": 60333.52527692134, "liquidity": 22289268.62, "decimals": 8 },
+          "executionQuality": { "isEligibleForPrimary": true },
+          "liquidityTier": "tier1",
+          "trustTier": "tier1"
+        },
+        {
+          "variantId": "bitcoin:wBTC",
+          "mint": "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh",
+          "symbol": "wBTC",
+          "market": { "price": 60219.1949427377, "liquidity": 4569240.93, "decimals": 8 },
+          "executionQuality": null,
+          "liquidityTier": "tier2",
+          "trustTier": "tier2"
+        }
+      ]
+    }"#;
+
+    fn doc() -> Value {
+        serde_json::from_str(BITCOIN).unwrap()
+    }
+
+    #[test]
+    fn primary_picks_canonical_variant_and_scales_price() {
+        let q = select_quotes(&doc(), &Variant::Primary, 6);
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0].label, "cbBTC");
+        assert_eq!(q[0].key, "cbbtcf3aa214zXHbiAZQwf4122FBYbraNdFqgw4iMij");
+        // 60333.52527692134 truncated to 6 decimals -> 60_333_525_276
+        assert_eq!(q[0].price, 60_333_525_276);
+    }
+
+    #[test]
+    fn all_returns_every_variant() {
+        let q = select_quotes(&doc(), &Variant::All, 6);
+        assert_eq!(q.len(), 2);
+        assert_eq!(q[1].label, "wBTC");
+        assert_eq!(q[1].price, 60_219_194_942);
+    }
+
+    #[test]
+    fn mint_selects_one() {
+        let q = select_quotes(
+            &doc(),
+            &Variant::Mint("3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh".to_string()),
+            6,
+        );
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0].label, "wBTC");
+    }
+
+    #[test]
+    fn median_across_tiers_mediates_price() {
+        // median of cbBTC (60_333_525_276) and wBTC (60_219_194_942) = mean of the two
+        let q = select_quotes(&doc(), &Variant::Median(vec![Tier::Tier1, Tier::Tier2]), 6);
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0].key, "bitcoin"); // aggregate keyed by asset, not a mint
+        assert_eq!(q[0].price, 60_276_360_109);
+    }
+
+    #[test]
+    fn median_respects_tier_allowlist() {
+        // tier1 only -> just cbBTC
+        let q = select_quotes(&doc(), &Variant::Median(vec![Tier::Tier1]), 6);
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0].price, 60_333_525_276);
+        // tier3 only -> no allowed variants -> no quote
+        let none = select_quotes(&doc(), &Variant::Median(vec![Tier::Tier3]), 6);
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn primary_falls_back_to_tier1_without_exec_quality() {
+        let doc: Value = serde_json::from_str(
+            r#"{"assetId":"x","variants":[
+                {"variantId":"x:a","mint":"A","symbol":"A","market":{"price":"1.5","liquidity":1},"liquidityTier":"tier2","trustTier":"tier2"},
+                {"variantId":"x:b","mint":"B","symbol":"B","market":{"price":"2.0","liquidity":2},"liquidityTier":"tier1","trustTier":"tier1"}
+            ]}"#,
+        )
+        .unwrap();
+        let q = select_quotes(&doc, &Variant::Primary, 6);
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0].label, "B");
+    }
+}


### PR DESCRIPTION
Add the doppler-feeder crate: a Feeder run-loop over the existing SDK Builder,
plus pluggable price sources behind a common interface:
- Coinbase and Binance keyless exchange tickers (response shapes verified live)
- TokensXyz native source: asset/variant selection + tier-filtered median
- RawSource: config-driven any-JSON source (URL template + JSON Pointer + aggregate)

Shared no-float decimal scaling and median/mean aggregation; sequence is
push-time millis (monotonic + freshness stamp). Unit-tested. CLI (doppler
init/run), multi-asset wiring, and a TS SDK follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feeder component for regularly fetching prices and pushing updates on a schedule.
  * Introduced support for multiple price sources, including a configurable HTTP-based source and a native tokens data source.
  * Added a starter binary with environment-based configuration for running the feeder.

* **Documentation**
  * Added usage, setup, and local run instructions for the feeder, including configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->